### PR TITLE
Changed the density functions to use 3x floats instead of 3x ints.

### DIFF
--- a/Assets/Examples/Scripts/Density Functions/BoxDensity.cs
+++ b/Assets/Examples/Scripts/Density Functions/BoxDensity.cs
@@ -10,7 +10,7 @@ namespace MarchingCubes.Examples.DensityFunctions
         [SerializeField] protected Vector3 center;
         [SerializeField] protected Vector3 size;
 
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             Vector3 p = new Vector3(x, y, z) - center;
             Vector3 d = p.Abs() - size;

--- a/Assets/Examples/Scripts/Density Functions/DensityFunction.cs
+++ b/Assets/Examples/Scripts/Density Functions/DensityFunction.cs
@@ -4,6 +4,6 @@ namespace MarchingCubes.Examples.DensityFunctions
 {
     public abstract class DensityFunction : ScriptableObject
     {
-        public abstract float CalculateDensity(int x, int y, int z);
+        public abstract float CalculateDensity(float x, float y, float z);
     }
 }

--- a/Assets/Examples/Scripts/Density Functions/FlatPlaneDensity.cs
+++ b/Assets/Examples/Scripts/Density Functions/FlatPlaneDensity.cs
@@ -7,7 +7,7 @@ namespace MarchingCubes.Examples.DensityFunctions
     {
         [SerializeField] private float groundLevel;
         
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             return y - groundLevel + 0.5f;
         }

--- a/Assets/Examples/Scripts/Density Functions/RoundBoxDensity.cs
+++ b/Assets/Examples/Scripts/Density Functions/RoundBoxDensity.cs
@@ -9,7 +9,7 @@ namespace MarchingCubes.Examples.DensityFunctions
     {
         [SerializeField] private float rounding;
 
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             return base.CalculateDensity(x, y, z) - rounding;
         }

--- a/Assets/Examples/Scripts/Density Functions/SphereDensity.cs
+++ b/Assets/Examples/Scripts/Density Functions/SphereDensity.cs
@@ -8,7 +8,7 @@ namespace MarchingCubes.Examples.DensityFunctions
         [SerializeField] private Vector3 center;
         [SerializeField] private float radius;
 
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             float newX = x - center.x;
             float newY = y - center.y;

--- a/Assets/Examples/Scripts/Density Functions/TerrainDensity.cs
+++ b/Assets/Examples/Scripts/Density Functions/TerrainDensity.cs
@@ -17,7 +17,7 @@ namespace MarchingCubes.Examples.DensityFunctions
             _noise = new FastNoise(seed);
         }
 
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             return y - _noise.GetPerlin(x / noiseScale, z / noiseScale).Map(-1, 1, 0, 1) * heightScale - groundLevel + 0.5f;
         }

--- a/Assets/Examples/Scripts/Density Functions/TorusDensityFunction.cs
+++ b/Assets/Examples/Scripts/Density Functions/TorusDensityFunction.cs
@@ -10,7 +10,7 @@ namespace MarchingCubes.Examples.DensityFunctions
         [SerializeField] private Vector3 center;
         [SerializeField] private Vector2 size;
 
-        public override float CalculateDensity(int x, int y, int z)
+        public override float CalculateDensity(float x, float y, float z)
         {
             Vector3 p = new Vector3(x, y, z) - center;
             Vector2 q = new Vector2(new Vector2(p.x, p.z).magnitude - size.x, p.y);

--- a/Assets/Scripts/ValueGridExtensions.cs
+++ b/Assets/Scripts/ValueGridExtensions.cs
@@ -4,7 +4,7 @@ namespace MarchingCubes
 {
     public static class ValueGridExtensions
     {
-        public static void Populate<T>(this ValueGrid<T> valueGrid, Func<int, int, int, T> fillFunction, int offsetX = 0, int offsetY = 0, int offsetZ = 0)
+        public static void Populate<T>(this ValueGrid<T> valueGrid, Func<float, float, float, T> fillFunction, int offsetX = 0, int offsetY = 0, int offsetZ = 0)
         {
             int width = valueGrid.Width;
             int height = valueGrid.Height;


### PR DESCRIPTION
Hi there, I'm the youtube commenter who requested that this be tweaked to support non-integer scales. Ex: the terrain plane could have some fractional dimensions such as 1.5 width x 1.5 length. I'm working on a VR sculpting experience where this functionality would be useful.

There are some code changes (like this first PR) that would not affect the current functionality at all. 